### PR TITLE
Fix typo in service config description

### DIFF
--- a/cmd/guardiand/main.go
+++ b/cmd/guardiand/main.go
@@ -39,7 +39,7 @@ func main() {
 
 	app := &cli.App{
 		Name:        "guardiand",
-		Description: "Runs and installs the guardian daemon",
+		Description: "Installs and runs the guardian daemon",
 		Usage:       "guardiand [subcommand] [opts]",
 
 		Flags: runFlags,

--- a/cmd/guardiand/main.go
+++ b/cmd/guardiand/main.go
@@ -13,7 +13,7 @@ func main() {
 	svcConfig := &service.Config{
 		Name:        "guardiand",
 		DisplayName: "guardiand",
-		Description: "The guardin service for VanillaVerse.",
+		Description: "The guardian service for VanillaVerse.",
 	}
 
 	dmn := &daemon.Daemon{}


### PR DESCRIPTION
I'd also suggest "daemon" instead of "service".